### PR TITLE
fix: Type check errors in posts.tsx (missing null checks)

### DIFF
--- a/apps/nextjs/src/app/_components/posts.tsx
+++ b/apps/nextjs/src/app/_components/posts.tsx
@@ -308,9 +308,7 @@ export function PostCard(props: {
         </div>
       </div>
       <div className="flex w-full justify-start">
-        <p className="text-xs">
-          {postDate.toLocaleDateString()}
-        </p>
+        <p className="text-xs">{postDate.toLocaleDateString()}</p>
       </div>
       <div className="flex-grow text-sm">{props.post.reviewDescription}</div>
       <Button

--- a/apps/nextjs/src/app/_components/posts.tsx
+++ b/apps/nextjs/src/app/_components/posts.tsx
@@ -246,11 +246,9 @@ export function PostCard(props: {
     },
   });
 
-  const formattedDate = props.post.date.toLocaleString();
-
-  const regex = /^(\d{4})-(\d{2})-(\d{2})$/;
-  const match = formattedDate.match(regex);
-  const [, year, month, day] = match;
+  // props.post.date is currently type string ...
+  // Initialize as Date (defaulting to start of epoch)
+  const postDate = new Date(props.post.date ?? 0);
 
   return (
     <div className="border-base h-full w-full border-b-2">
@@ -311,7 +309,7 @@ export function PostCard(props: {
       </div>
       <div className="flex w-full justify-start">
         <p className="text-xs">
-          {day} {month}, {year}
+          {postDate.toLocaleDateString()}
         </p>
       </div>
       <div className="flex-grow text-sm">{props.post.reviewDescription}</div>

--- a/apps/nextjs/src/app/_components/posts.tsx
+++ b/apps/nextjs/src/app/_components/posts.tsx
@@ -207,6 +207,12 @@ export function PostList(props: {
     initialData,
   });
 
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
   if (posts.length === 0) {
     return (
       <div className="relative flex w-full flex-col items-center gap-4">
@@ -218,6 +224,11 @@ export function PostList(props: {
         </div>
       </div>
     );
+  }
+
+  // Avoid pre-render on post list -- prevents issues with date formatting
+  if (!isMounted) {
+    return <h4>Loading...</h4>;
   }
 
   return (


### PR DESCRIPTION
Fixes one of the type errors occurring from #56 -- locally I am also getting these errors:

![image](https://github.com/restauwants/restauwants/assets/147473940/d0348360-38e6-4e49-9447-058969d1da00)

These issues appear to stem from [`/apps/nextjs/src/app/api/trpc/[trpc]/route.ts`](https://github.com/restauwants/restauwants/blob/edf6c27cdd97ecfa83743d8853ca44cb02c548eb/my-turborepo/apps/nextjs/src/app/api/trpc/%5Btrpc%5D/route.ts) on lines 27-40 and are possibly related to [this issue on the create-t3-turbo GitHub](https://github.com/t3-oss/create-t3-turbo/issues/800).

**Diagnosis:** removing the auth handler and its corresponding export in the file resolves the remaining type errors obtained when running `pnpm run typecheck`.

Further reading: The create-t3-turbo issue above, or possibly [this one](https://github.com/nextauthjs/next-auth/issues/8243) might be places to start.